### PR TITLE
Feature/check cookie in start

### DIFF
--- a/app/views/application/_abraham.html.erb
+++ b/app/views/application/_abraham.html.erb
@@ -51,8 +51,14 @@
   });
   <% end %>
 
-  // Don't start the tour if the user dismissed it once this session
-  if (!Cookies.get('<%= abraham_cookie_prefix %>-<%= tour_name %>', { domain: '<%= abraham_domain %>' })) {
-    tour.start();
-  }
+  tour.start = function (start) {
+    return function () {
+      // Don't start the tour if the user dismissed it once this session
+      if (!Cookies.get('<%= abraham_cookie_prefix %>-<%= tour_name %>', {domain: '<%= abraham_domain %>'})) {
+        start();
+      }
+    }
+  }(tour.start)
+
+  tour.start()
 </script>


### PR DESCRIPTION
We need a way to start a tour from a user action.  In this case, the user clicks a toggle button (built as a React component) and the click causes a tour to appear.

In order to honor the Abraham "later" cookie to only show the tour once per session, we need the start method to check the cookie when it is called after the page has loaded.  In this PR we wrap the existing start method with a wrapper function that checks the cookie status.