### PR TITLE
Do not attempt to create AbrahamHistory if there is no current_user or if user is a guest.

### DIFF
--- a/app/controllers/abraham_histories_controller.rb
+++ b/app/controllers/abraham_histories_controller.rb
@@ -2,6 +2,7 @@
 
 class AbrahamHistoriesController < ApplicationController
   def create
+    head :no_content if current_user.blank? || (current_user.respond_to?(:guest?) && current_user.guest?)
     @abraham_history = AbrahamHistory.new(abraham_history_params)
     @abraham_history.creator_id = current_user.id
     respond_to do |format|


### PR DESCRIPTION
I would like to be able to give tours to unlogged users / guest users.
Thus, the controller should not create AbrahamHistory when there is no `current_user` or when the host rails app implement a guest user system.
 
I couldn't really run the test suite locally and the controller test case is currently tighly coupled with giving a "fake" user id, so I'm open to suggestions to work on that !