### PR TITLE
Better javascript escaping

### DIFF
--- a/app/views/application/_abraham.html.erb
+++ b/app/views/application/_abraham.html.erb
@@ -29,10 +29,10 @@
     <% end %>
     text: "<%= step['text'] %>",
     <% if step.key?('attachTo') %>
-    attachTo: { element: "<%= step['attachTo']['element'] %>", on: "<%= step['attachTo']['placement'] %>" },
+    attachTo: { element: "<%= escape_javascript(step['attachTo']['element'].html_safe) %>", on: "<%= step['attachTo']['placement'] %>" },
     showOn: function() {
       // Only display this step if its selector is present
-      return document.querySelector("<%= step['attachTo']['element'] %>") ? true : false
+      return document.querySelector("<%= escape_javascript(step['attachTo']['element'].html_safe) %>") ? true : false
     },
     <% end %>
     buttons: [

--- a/test/dummy/config/tours/dashboard/home.en.yml
+++ b/test/dummy/config/tours/dashboard/home.en.yml
@@ -1,24 +1,24 @@
 intro:
   steps:
     1:
-      text: "ENGLISH This first HOME step is centered text-only"
+      text: "ENGLISH This first HOME step is centered & 'text-only'"
     2:
-      title: "ENGLISH This step has a title"
-      text: "ENGLISH This intermediate step has some text"
+      title: "ENGLISH This step has a \"title\""
+      text: 'ENGLISH This intermediate step has "some text"'
     3:
       title: "ENGLISH A missing step"
       text: "ENGLISH Refers to an element that won't exist on the page, should skip to 4"
       attachTo:
-        element: "#i-dont-exist"
+        element: "* > #i-dont-exist"
         placement: "right"
     4:
       title: "ENGLISH The final step"
       text: "ENGLISH Some text here too, and it's attached to the right"
       attachTo:
-        element: ".notice-me"
+        element: '[class="notice-me"]'
         placement: "right"
 a_manual_tour:
-  trigger: manual
+  trigger: "manual"
   steps:
     1:
       text: "You triggered the manual tour"

--- a/test/dummy/test/controllers/dashboard_controller_test.rb
+++ b/test/dummy/test/controllers/dashboard_controller_test.rb
@@ -36,8 +36,8 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
 
     assert_select "body script" do |element|
       # it's the home tour
-      assert element.text.include? "ENGLISH This first HOME step is centered text-only"
-      # it has three steps
+      assert element.text.include? "ENGLISH This first HOME step is centered &amp; &#39;text-only&#39;"
+      # it has four steps
       assert element.text.include? "step-1"
       assert element.text.include? "step-2"
       assert element.text.include? "step-3"

--- a/test/dummy/test/system/tours_test.rb
+++ b/test/dummy/test/system/tours_test.rb
@@ -12,7 +12,7 @@ class ToursTest < ApplicationSystemTestCase
 
     # Tour Step 1
     assert_selector ".shepherd-element", visible: true
-    assert_selector ".shepherd-text", text: "ENGLISH This first HOME step is centered text-only"
+    assert_selector ".shepherd-text", text: "ENGLISH This first HOME step is centered & 'text-only'"
     assert_selector ".shepherd-button", text: "Later"
     assert_selector ".shepherd-button", text: "Continue"
     find(".shepherd-button", text: "Continue").click
@@ -23,8 +23,8 @@ class ToursTest < ApplicationSystemTestCase
     assert_selector ".shepherd-element", count: 1, visible: true
 
     # Tour Step 2
-    assert_selector ".shepherd-header", text: "ENGLISH This step has a title"
-    assert_selector ".shepherd-text", text: "ENGLISH This intermediate step has some text"
+    assert_selector ".shepherd-header", text: "ENGLISH This step has a \"title\""
+    assert_selector ".shepherd-text", text: "ENGLISH This intermediate step has \"some text\""
     assert_selector ".shepherd-button", text: "Exit"
     assert_selector ".shepherd-button", text: "Next"
     find(".shepherd-button", text: "Next").click


### PR DESCRIPTION
Improved escaping of configuration variables inserted into JavaScript, including `attachTo` query selectors.

Fixes #65